### PR TITLE
update for PDI6 using vfs2

### DIFF
--- a/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/AbstractFileReader.java
+++ b/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/AbstractFileReader.java
@@ -28,7 +28,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.vfs.FileSystemException;
+import org.apache.commons.vfs2.FileSystemException;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.vfs.KettleVFS;
 

--- a/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/AbstractFileWriter.java
+++ b/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/AbstractFileWriter.java
@@ -28,7 +28,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.vfs.FileSystemException;
+import org.apache.commons.vfs2.FileSystemException;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.vfs.KettleVFS;
 


### PR DESCRIPTION
Just made a couple changes to reference vfs2 instead of vfs. It compiles and I did a simple test in PDI6.1. 
