### PR TITLE
Corrected GIS File Input Shapefile multiple steps + paths with spaces

### DIFF
--- a/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/AbstractFileReader.java
+++ b/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/AbstractFileReader.java
@@ -24,8 +24,9 @@ package com.atolcd.pentaho.di.gis.io;
 
 
 import java.io.IOException;
-import java.net.URL;
+import java.net.URLDecoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -90,10 +91,10 @@ public abstract class AbstractFileReader implements FileReader {
     }
 
     // Vérification du nom de fichier
-    protected URL checkFilename(String filename) throws KettleException {
+    protected String checkFilename(String filename) throws KettleException {
 
         try {
-            return KettleVFS.getFileObject(filename).getURL();
+            return URLDecoder.decode(KettleVFS.getFileObject(filename).getURL().getFile(), StandardCharsets.UTF_8.name());
 
         } catch (IOException e) {
 

--- a/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/DXFReader.java
+++ b/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/DXFReader.java
@@ -49,12 +49,12 @@ public class DXFReader extends AbstractFileReader {
         super(null, geometryFieldName, charsetName);
 
         try {
-            this.dxfFileExist = new File(checkFilename(fileName).getFile()).exists();
+            this.dxfFileExist = new File(checkFilename(fileName)).exists();
 
             if (!this.dxfFileExist) {
                 throw new KettleException("Missing " + fileName + " file");
             } else {
-                this.dxfFileName = checkFilename(fileName).getFile();
+                this.dxfFileName = checkFilename(fileName);
             }
             this.readXData = readXData;
 

--- a/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/GPXReader.java
+++ b/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/GPXReader.java
@@ -47,12 +47,12 @@ public class GPXReader extends AbstractFileReader {
         super(null, geometryFieldName, charsetName);
 
         try {
-            this.gpxFileExist = new File(checkFilename(fileName).getFile()).exists();
+            this.gpxFileExist = new File(checkFilename(fileName)).exists();
 
             if (!this.gpxFileExist) {
                 throw new KettleException("Missing " + fileName + " file");
             } else {
-                this.gpxFileName = checkFilename(fileName).getFile();
+                this.gpxFileName = checkFilename(fileName);
             }
 
             this.fields.add(new Field(geometryFieldName, FieldType.GEOMETRY, null, null));

--- a/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/GeoJSONReader.java
+++ b/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/GeoJSONReader.java
@@ -51,12 +51,12 @@ public class GeoJSONReader extends AbstractFileReader {
 
         super(null, geometryFieldName, charsetName);
 
-        this.geoJsonFileExist = new File(checkFilename(fileName).getFile()).exists();
+        this.geoJsonFileExist = new File(checkFilename(fileName)).exists();
 
         if (!this.geoJsonFileExist) {
             throw new KettleException("Missing " + fileName + " file");
         } else {
-            this.geoJsonFileName = checkFilename(fileName).getFile();
+            this.geoJsonFileName = checkFilename(fileName);
         }
 
         this.fields.add(new Field(geometryFieldName, FieldType.GEOMETRY, null, null));

--- a/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/GeoPackageReader.java
+++ b/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/GeoPackageReader.java
@@ -74,12 +74,12 @@ public class GeoPackageReader extends AbstractFileReader {
 
         super(tableName, null, charsetName);
 
-        this.gpkgFileExist = new File(checkFilename(fileName).getFile()).exists();
+        this.gpkgFileExist = new File(checkFilename(fileName)).exists();
 
         if (!this.gpkgFileExist) {
             throw new KettleException("Missing " + fileName + " file");
         } else {
-            this.gpkgFileName = checkFilename(fileName).getFile();
+            this.gpkgFileName = checkFilename(fileName);
         }
         
         if(tableName.equalsIgnoreCase("*")){

--- a/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/MapInfoReader.java
+++ b/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/MapInfoReader.java
@@ -50,13 +50,13 @@ public class MapInfoReader extends AbstractFileReader {
 
         try {
 
-            this.mifFileExist = new File(checkFilename(fileName).getFile()).exists();
-            this.midFileExist = new File(checkFilename(replaceFileExtension(fileName, ".mif", ".mid")).getFile()).exists();
+            this.mifFileExist = new File(checkFilename(fileName)).exists();
+            this.midFileExist = new File(checkFilename(replaceFileExtension(fileName, ".mif", ".mid"))).exists();
 
             if (!this.mifFileExist) {
                 throw new KettleException("Missing " + fileName + " file");
             } else {
-                this.mifFileName = checkFilename(fileName).getFile();
+                this.mifFileName = checkFilename(fileName);
             }
 
             if (!this.midFileExist) {

--- a/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/ShapefileReader.java
+++ b/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/ShapefileReader.java
@@ -40,6 +40,8 @@ import com.atolcd.pentaho.di.gis.io.features.Feature;
 import com.atolcd.pentaho.di.gis.io.features.Field;
 import com.atolcd.pentaho.di.gis.io.features.Field.FieldType;
 import com.atolcd.pentaho.di.gis.utils.GeometryUtils;
+import com.linuxense.javadbf.DBFField;
+import com.linuxense.javadbf.DBFReader;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryCollection;
 import com.vividsolutions.jts.geom.GeometryFactory;
@@ -152,30 +154,23 @@ public class ShapefileReader extends AbstractFileReader {
             shapefile.close();
 
             if (this.dbfFileExist) {
-
-                // DbfFile dbfFile = new DbfFile(this.dbfFileName, this.charset);
-                // for (int i = 0; i < features.size(); i++) {
-
-                //     byte[] record = dbfFile.GetDbfRec(i);
-
-                //     for (int j = 0; j < this.getFields().size() - 1; j++) {
-                //         features.get(i).addValue(this.fields.get(j + 1), dbfFile.ParseRecordColumn(record, j));
-                //     }
-
-                // }
-
-                // dbfFile.close();
-
                 
                 XBase xbase = new XBase(null, dbfFileName);
 
                 xbase.setDbfFile(dbfFileName);
                 xbase.open();
+
+                DBFReader reader = xbase.getReader();
+                reader.setCharactersetName(this.charset.name());
                 
-                xbase.getReader().setCharactersetName(this.charset.name());
+                for (int i = 0; i < xbase.getReader().getFieldCount(); i++){
+                    if (reader.getField(i).getDataType() == DBFField.FIELD_TYPE_F){
+                        reader.getField(i).setDataType(DBFField.FIELD_TYPE_N);
+                    }
+                }
                 for (int i = 0; i < features.size(); i++) {
 
-                    Object[] record = xbase.getReader().nextRecord();
+                    Object[] record = reader.nextRecord();
 
                     for (int j = 0; j < this.getFields().size() - 1; j++) {
                         features.get(i).addValue(this.fields.get(j + 1), record[j]);

--- a/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/SpatialiteReader.java
+++ b/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/SpatialiteReader.java
@@ -49,12 +49,12 @@ public class SpatialiteReader extends AbstractFileReader {
 
         super(tableName, null, charsetName);
 
-        this.spatialiteFileExist = new File(checkFilename(fileName).getFile()).exists();
+        this.spatialiteFileExist = new File(checkFilename(fileName)).exists();
 
         if (!this.spatialiteFileExist) {
             throw new KettleException("Missing " + fileName + " file");
         } else {
-            this.spatialiteFileName = checkFilename(fileName).getFile();
+            this.spatialiteFileName = checkFilename(fileName);
         }
 
         if(tableName.equalsIgnoreCase("*")){

--- a/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/features/FeatureConverter.java
+++ b/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/features/FeatureConverter.java
@@ -221,6 +221,7 @@ public final class FeatureConverter {
                     value = valueMeta.getNumber(featureValue);
 
                 } else if (field.getType().equals(FieldType.LONG)) {
+
                     if(featureValue instanceof Double){
                         featureValue = Double.valueOf( (Double) featureValue).longValue();
                     }

--- a/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/features/FeatureConverter.java
+++ b/pentaho-gis-plugins/src/main/java/com/atolcd/pentaho/di/gis/io/features/FeatureConverter.java
@@ -221,11 +221,14 @@ public final class FeatureConverter {
                     value = valueMeta.getNumber(featureValue);
 
                 } else if (field.getType().equals(FieldType.LONG)) {
+                    if(featureValue instanceof Double){
+                        featureValue = Double.valueOf( (Double) featureValue).longValue();
+                    }
 
                     value = valueMeta.getInteger(Long.parseLong(String.valueOf(featureValue)));
 
                 } else {
-                    value = valueMeta.getString(String.valueOf(featureValue));
+                    value = valueMeta.getString(String.valueOf(featureValue).trim());
                 }
 
             }


### PR DESCRIPTION
I had a problem with the GIS File Input step where an error occured if I had two or more steps of this kind with the shapefile input option. Apparently, while reading the DBF associated file, the stream in RandomAccessFile would be corrupted, and the step threw a NumberFormatException for date and numeric fields. I changed the way it reads a DBF file with the XBase class built in Pentaho. I also changed how it converts a field to Long, because XBase inputs Longs as Doubles, and the FeatureConverter threw a format exception.

I also solved a problem with paths that contain spaces as it happened to me on Windows 10 (URL kept the space as %20, so it had to be decoded to work).